### PR TITLE
Fix issue #406 for 2 monitor configuration

### DIFF
--- a/src/outwiker/gui/mainwindow.py
+++ b/src/outwiker/gui/mainwindow.py
@@ -549,14 +549,6 @@ class MainWindow(wx.Frame):
                     (width, height) = self.GetSize()
                     (xpos, ypos) = self.GetPosition()
 
-                    if xpos < 0:
-                        width += xpos
-                        xpos = 0
-
-                    if ypos < 0:
-                        height += ypos
-                        ypos = 0
-
                     self.mainWindowConfig.width.value = width
                     self.mainWindowConfig.height.value = height
 


### PR DESCRIPTION
Если главный онирор настроен правым, то функция SetSize возвращает x в отрицательной зоне.
Однако функция _saveParams отрицательное число приводило к 0 а размер окна вычитала из координат.
в иотге окно появлялось в позиции ноль и с минимальной шириной, что и приводило к сплющиванию.
Удалил проверку на отрицательное число, теперь работает корректно, но тесты gui на винде прогнать не вышло, зависают.
