### PR TITLE
Fix the different coding of params.link attribute for onLinkClicked Event.

### DIFF
--- a/src/outwiker/gui/htmlrenderwebkit.py
+++ b/src/outwiker/gui/htmlrenderwebkit.py
@@ -171,7 +171,7 @@ class HtmlRenderWebKit(HtmlRender):
         modifier = self.__gtk2OutWikerKeyCode(gtk_key_modifier)
         mouse_button = self.__gtk2OutWikerMouseButtonCode(gtk_mouse_button)
 
-        params = self._getClickParams(source_href.encode('ascii'),
+        params = self._getClickParams(source_href,
                                       mouse_button,
                                       modifier,
                                       url,


### PR DESCRIPTION
utf8 string is using for Windows and Linux