### PR TITLE
Merge branch 'dev' of https://github.com/Jenyay/outwiker into pluginsLoader_ref

### DIFF
--- a/src/outwiker/core/pluginsloader.py
+++ b/src/outwiker/core/pluginsloader.py
@@ -366,6 +366,30 @@ class PluginsLoader (object):
             # import plugin again
             self.__importPackage(plug_path)
 
+    def getInfo(self, pluginname, langlist=["en"]):
+        """
+        Retrieve a AppInfo for plugin_name
+        :param pluginname:
+            name of the loaded plugin
+        :param lang:
+            langlist - list of the languages name ("en", "ru_RU" etc)
+        :return:
+            AppInfo for pluginname
+            if pluginname cannot be located, then None is returned.
+        :exception IOError:
+            if plugin.xml cannot be read
+        """
+        if pluginname in self.__plugins:
+            module = self.__plugins[pluginname].__class__.__module__
+        elif pluginname in self.__disabledPlugins:
+            module = self.__disabledPlugins[pluginname].__class__.__module__
+        else:
+            module = ''
+
+        xml_content = pkgutil.get_data(module, PLUGIN_VERSION_FILE_NAME)
+        if xml_content:
+            return XmlVersionParser(langlist).parse(xml_content)
+
 
     def __len__(self):
         return len(self.__plugins)

--- a/src/test/test_pluginsloader.py
+++ b/src/test/test_pluginsloader.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from outwiker.core.pluginsloader import PluginsLoader
+from outwiker.core.appinfo import AppInfo
 from outwiker.gui.guiconfig import PluginsConfig
 from test.basetestcases import BaseOutWikerMixin
 import unittest
@@ -328,3 +329,40 @@ class PluginsLoaderTest(BaseOutWikerMixin, unittest.TestCase):
         self.assertEqual(len(loader.invalidPlugins), 1)
         # self.assertIn(u'Please, update the plug-in.',
         #               loader.invalidPlugins[0].description)
+
+    def testGetInfo(self):
+        dirlist = ["../test/plugins/testempty1",]
+        loader = PluginsLoader(self.application)
+        loader.load(dirlist)
+
+        self.assertEqual(len(loader), 1)
+        self.assertEqual(loader["TestEmpty1"].name, "TestEmpty1")
+        self.assertEqual(loader["TestEmpty1"].version, "0.1")
+
+        plugInfo = loader.getInfo("TestEmpty1")
+        self.assertIsInstance(plugInfo, AppInfo)
+
+    def testGetInfo_disabled(self):
+        # Добавим плагин TestEmpty1 в черный список
+        self.config.disabledPlugins.value = ["TestEmpty1"]
+
+        dirlist = ["../test/plugins/testempty1", ]
+        loader = PluginsLoader(self.application)
+        loader.load(dirlist)
+
+        self.assertEqual(len(loader), 0)
+        self.assertEqual(len(loader.disabledPlugins), 1)
+
+        plugInfo = loader.getInfo("TestEmpty1")
+        self.assertIsInstance(plugInfo, AppInfo)
+
+
+    def testGetInfo_None(self):
+        dirlist = ["../test/plugins/testempty1",]
+        loader = PluginsLoader(self.application)
+        loader.load(dirlist)
+
+        self.assertEqual(len(loader), 1)
+
+        plugInfo = loader.getInfo("Wring_module")
+        self.assertIs(plugInfo, None)


### PR DESCRIPTION
PluginLoader is response to plugin's instances.
Seems it should provide interface for plugin's information (plugin.xml)
 
P.S. По факту, сейчас данные из plugin.xml берёт только UpdateNotifer и fabrunner
можно и не трогать, но если у нас есть класс, который отвечает за загрузку модулей, 
мне кажется логичным сделать его ответсвенным и за загрузку ресурсов этих классов.