### PR TITLE
excessive call saveHotKeys() was deleted from mainwindow destroy method.

### DIFF
--- a/src/outwiker/gui/mainwindow.py
+++ b/src/outwiker/gui/mainwindow.py
@@ -610,7 +610,6 @@ class MainWindow(wx.Frame):
         self._saveParams()
         self.destroyPagePanel(True)
 
-        self._application.actionController.saveHotKeys()
         self._application.clear()
         self._application.actionController.destroy()
         self._application = None


### PR DESCRIPTION
Удалил избыточное сохранение горячих клавишь из метода destroy главного окна.
полное пересохранение происходит при установлении/изменении новой горячей клавишы.

P.S. незначительно сократилось время закрытия программы + у меня время выполнения gui 
тестов уменьшилось примерно на 30% с ~75s до ~43s.
