### PR TITLE
Add additional blockdiag output file format in diagrammer

### DIFF
--- a/plugins/diagrammer/diagrammer/diagramrender.py
+++ b/plugins/diagrammer/diagrammer/diagramrender.py
@@ -90,10 +90,11 @@ class DiagramRender(object):
         from blockdiag.imagedraw.png import setup
         setup(None)
 
-    def renderToFile(self, content, imagePath):
+    def renderToFile(self, content, imagePath, fileType="png"):
         """
         content - текст, описывающий диаграмму
         imagePath - полный путь до создаваемого файла
+        fileType - filetype of the output file, either png or pdf
         """
         from blockdiag.parser import parse_string
         from blockdiag.drawer import DiagramDraw
@@ -112,7 +113,7 @@ class DiagramRender(object):
         tree = parse_string(text)
         diagram = ScreenNodeBuilder.build(tree)
 
-        draw = DiagramDraw("png", diagram, imagePath,
+        draw = DiagramDraw(fileType, diagram, imagePath,
                            fontmap=fontmap, antialias=True)
         draw.draw()
         draw.save()


### PR DESCRIPTION
The method `renderToFile` has it's output file format hardcoded as `"png"`.
Blockdiag also supports PDF, therefore it could be a valid argument for this function.

This pull request adds a parameter for this, and executes blockdiag dynamically with it.

The argument is not used outside the scope of this function, as I'm not aware of the exact context in which it is executed, as it's been a long time since I've used this program, but I remember wanting the option back then.